### PR TITLE
docs - secdao-2 alternative

### DIFF
--- a/multisig/secdao-2.md
+++ b/multisig/secdao-2.md
@@ -32,7 +32,7 @@ In the course of SecurityDAOs operation from the time of the [IWP-5](https://git
 
 Over time, this structure has shown its limitations as an incentive mechanism that delivers timely outcomes and now needs revision.
 
-`secdao-2` aims to make this pause in UBI explicit, propose concrete ways in which the treasury can be allocated in the meantime that can be verifiably executed on-chain.
+`secdao-2` aims to make this pause in UBI explicit, as well as propose concrete ways in which the treasury can be allocated in the meantime that can be verifiably executed on-chain.
 
 ## Actions to be carried out on-chain
 * deploy `16,000 $UST` equivalent of treasury at the time of execution to [`$STARS / $ATOM` liquidity pool on Osmosis #611](https://info.osmosis.zone/pool/611) with 14 days unbonding period (maximum yield)


### PR DESCRIPTION
`l'illusione è la gramigna più tenace della coscienza collettiva: la storia insegna, ma non ha scolari`

This attempts to refine the `secdao-2` to more concisely capture the immediate the pausing of UBI specifically and lay the foundation for more proposals / consensus to emerge around other (very important!) observations made by @rakataprime

The biggest difference is also to introduce LP yield for a portion of treasury funds on top of the pause as a way to get one step closer to being default alive / getting comp from yield rather than eating away at the treasury etc.

Would love any and all feedback, discussions, commits with edits etc.

Thanks!