### PR TITLE
Prop 21 - vote by validator!

### DIFF
--- a/ring-juno-validator/ring-juno-validator-3.json
+++ b/ring-juno-validator/ring-juno-validator-3.json
@@ -19,7 +19,7 @@
       "amount": [
         {
           "denom": "ujuno",
-          "amount": "7420"
+          "amount": "10101"
         }
       ],
       "gas_limit": "400000",

--- a/ring-juno-validator/ring-juno-validator-3.json
+++ b/ring-juno-validator/ring-juno-validator-3.json
@@ -3,7 +3,7 @@
     "messages": [
       {
         "@type": "/cosmos.gov.v1beta1.MsgVote",
-        "proposal_id": "20",
+        "proposal_id": "21",
         "voter": "juno1n33nhm7fes7umlw58lld77pkgh7qlp8lgphk9r",
         "option": "VOTE_OPTION_ABSTAIN"
       }

--- a/ring-juno-validator/ring-juno-validator-3.json
+++ b/ring-juno-validator/ring-juno-validator-3.json
@@ -1,0 +1,31 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.gov.v1beta1.MsgVote",
+        "proposal_id": "20",
+        "voter": "juno1n33nhm7fes7umlw58lld77pkgh7qlp8lgphk9r",
+        "option": "VOTE_OPTION_ABSTAIN"
+      }
+    ],
+    "memo": "We welcome gov as code, but as the DAO to audit, it is a principled Abstain (delegators can override)",
+    "timeout_height": "0",
+    "extension_options": [],
+    "non_critical_extension_options": []
+  },
+  "auth_info": {
+    "signer_infos": [],
+    "fee": {
+      "amount": [
+        {
+          "denom": "ujuno",
+          "amount": "7420"
+        }
+      ],
+      "gas_limit": "400000",
+      "payer": "",
+      "granter": ""
+    }
+  },
+  "signatures": []
+}

--- a/ring-juno-validator/ring-juno-validator-3.json
+++ b/ring-juno-validator/ring-juno-validator-3.json
@@ -8,7 +8,7 @@
         "option": "VOTE_OPTION_ABSTAIN"
       }
     ],
-    "memo": "We welcome gov as code, but as the DAO to audit, it is a principled Abstain (delegators can override)",
+    "memo": "We welcome gov as code, but in our capacity as the DAO to audit, it is a principled Abstain (token delegators can override)",
     "timeout_height": "0",
     "extension_options": [],
     "non_critical_extension_options": []


### PR DESCRIPTION
To be followed up with the blogpost as to why regardless of how we may feel individually, as a DAO with privileged information we need to refrain from politicking and maintain neutrality -- a principled `Abstain`.

As noted [previously](https://secdao.medium.com/its-time-to-end-text-proposals-without-code-no-on-prop18-6a9dc0f52844), the only exception will be a `No` vote to any text-only proposal.